### PR TITLE
Bump cmake_minimum_version to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.14)
 
 project(Bakcyl2020)
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ Ubuntu example:
 ```sh
 sudo apt-get install libsqlite3-dev libjsoncpp-dev qt5-default
 ```
+
+## Build
+Build requires cmake 3.14+
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```


### PR DESCRIPTION
FindSQLite3 is built-in to cmake from 3.14 version. Build fails with previous versions. 

Alternatively, we could include the FindSQLite3.cmake script in our repo.