### PR TITLE
Cmake "cannot create gtest target" bug fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,18 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-
-find_package(QT NAMES Qt5 COMPONENTS Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
-
-include(External_GTest.cmake)
-
-
-find_package(SQLite3 REQUIRED)
-find_package(JsonCpp REQUIRED)
-find_package(QT NAMES Qt5 COMPONENTS Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+find_package(SQLite3)
+if (NOT SQLite3_FOUND)
+    message(SEND_ERROR "sqlite3 package not found, please install it")
+endif()
+find_package(JsonCpp)
+if (NOT JsonCpp_FOUND)
+    message(SEND_ERROR "jsoncpp, or jsoncpp-dev package not found, please install it")
+endif()
+find_package(Qt5 COMPONENTS Widgets)
+if (NOT Qt5_FOUND)
+    message(SEND_ERROR "qt5 package not found, please install it")
+endif()
 
 include(External_GTest.cmake)
 
@@ -49,7 +50,7 @@ set(PROJECT_SOURCES
 
 add_executable(Deckbuilder ${PROJECT_SOURCES})
     
-target_link_libraries(Deckbuilder PRIVATE Qt${QT_VERSION_MAJOR}::Widgets ${SQLite3_LIBRARIES} JsonCpp::JsonCpp)
+target_link_libraries(Deckbuilder PRIVATE Qt5::Widgets ${SQLite3_LIBRARIES} JsonCpp::JsonCpp)
 
 
 # Valgrind


### PR DESCRIPTION
Przez podwójne zaincludowanie gtestu, projekt w ogóle się nie budował. W ogóle sporo było w tej liście niepotrzebnych duplikatów (i w ogóle niepotrzebnego kodu). Wszystkie duplikaty zostały usunięte, część rzeczy została delikatnie przepisana. Od razu dodałem też ify, które będą podstawą mojego rozwiązania #37 (w najbliższej przyszłości napiszę do nich kod który ściąga i kompiluje wszystkie potrzebne rzeczy w razie potrzeby)