### PR TITLE
Add db builder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LIBRARY_OUTPUT_PATH build/)
 set(BINARY_OUTPUT_PATH build/)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-g3 -pthread -fconcepts -Wall -Wno-error -pedantic")
+set(CMAKE_CXX_FLAGS "-g3 -pthread -fconcepts -Wall -pedantic")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
 #Qt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ add_executable(Deckbuilder ${PROJECT_SOURCES})
     
 target_link_libraries(Deckbuilder PRIVATE Qt5::Widgets ${SQLite3_LIBRARIES} JsonCpp::JsonCpp)
 
+# database builder
+include(${PROJECT_SOURCE_DIR}/db_builder/CMakeLists.txt)
 
 # Valgrind
 find_program(VALGRIND "valgrind")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(LIBRARY_OUTPUT_PATH build/)
 set(BINARY_OUTPUT_PATH build/)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-g3 -pthread -fconcepts -Wall -pedantic")
+set(CMAKE_CXX_FLAGS "-g3 -pthread -fconcepts -Wall -Wno-error -pedantic")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
 
 #Qt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,17 +14,18 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-
-find_package(QT NAMES Qt5 COMPONENTS Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
-
-include(External_GTest.cmake)
-
-
-find_package(SQLite3 REQUIRED)
-find_package(JsonCpp REQUIRED)
-find_package(QT NAMES Qt5 COMPONENTS Widgets REQUIRED)
-find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
+find_package(SQLite3)
+if (NOT SQLite3_FOUND)
+    message(SEND_ERROR "sqlite3 package not found, please install it")
+endif()
+find_package(JsonCpp)
+if (NOT JsonCpp_FOUND)
+    message(SEND_ERROR "jsoncpp, or jsoncpp-dev package not found, please install it")
+endif()
+find_package(Qt5 COMPONENTS Widgets)
+if (NOT Qt5_FOUND)
+    message(SEND_ERROR "qt5 package not found, please install it")
+endif()
 
 include(External_GTest.cmake)
 
@@ -49,7 +50,7 @@ set(PROJECT_SOURCES
 
 add_executable(Deckbuilder ${PROJECT_SOURCES})
     
-target_link_libraries(Deckbuilder PRIVATE Qt${QT_VERSION_MAJOR}::Widgets ${SQLite3_LIBRARIES} JsonCpp::JsonCpp)
+target_link_libraries(Deckbuilder PRIVATE Qt5::Widgets ${SQLite3_LIBRARIES} JsonCpp::JsonCpp)
 
 
 # Valgrind

--- a/db_builder/CMakeLists.txt
+++ b/db_builder/CMakeLists.txt
@@ -1,0 +1,9 @@
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.11.0")
+    file(GLOB SOURCE_FILES CONFIGURE_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/Source/*.cpp)
+else()
+    file(GLOB SOURCE_FILES ${CMAKE_CURRENT_LIST_DIR}/Source/*.cpp)
+endif()
+
+include_directories(${CMAKE_CURRENT_LIST_DIR}/Include)
+add_executable(db_builder ${SOURCE_FILES})
+target_link_libraries(db_builder JsonCpp::JsonCpp ${SQLite3_LIBRARIES})

--- a/db_builder/Include/jsonInserter.hpp
+++ b/db_builder/Include/jsonInserter.hpp
@@ -1,9 +1,9 @@
 #pragma once
 #include <json/json.h>
-#include <sqlite3.h>
+#include "sqlite_helper.hpp"
 #include <string>
 
-void fillTableWithArrOfDicts(sqlite3* db, const char table_name[], Json::Value arrOfDicts);
+void fillTableWithArrOfDicts(unique_sqlite3& db, const char table_name[], Json::Value arrOfDicts);
 // Iterates over json array of objects (we use dict as synonym) and inserts corresponing fields to table
 // If there is no corresponding field - inserts NULL
 // Example:

--- a/db_builder/Include/jsonInserter.hpp
+++ b/db_builder/Include/jsonInserter.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <json/json.h>
+#include <sqlite3.h>
+#include <string>
+
+void fillTableWithArrOfDicts(sqlite3* db, const char table_name[], Json::Value arrOfDicts);
+// Iterates over json array of objects (we use dict as synonym) and inserts corresponing fields to table
+// If there is no corresponding field - inserts NULL
+// Example:
+// We have table foobar with columns: foo, bar, foof
+// We pass json: [{"foo": "chuj", "bar": "dupa"}, {"foo": "chuj", "foof: "dupa"}]
+// table after filling:
+// | foo  | bar  |foof // headers
+// |"chuj"|"dupa"|NULL
+// |"chuj"| NULL |"dupa"

--- a/db_builder/Include/sqlite_helper.hpp
+++ b/db_builder/Include/sqlite_helper.hpp
@@ -1,7 +1,15 @@
 #pragma once
 #include <sqlite3.h>
 #include <string>
+#include <memory>
 
-sqlite3* open_db(const char db_name[]);
-void throwSqliteException(sqlite3* db, const std::string& errMsgPrefix, char* errMsgSuffix);
-void throwSqliteException(sqlite3* db, const std::string& errMsgPrefix);
+struct sqlite_deleter {
+  void operator()(sqlite3*  ptr) { if (ptr) sqlite3_close(ptr); }
+};
+using unique_sqlite3  = std::unique_ptr<sqlite3,  sqlite_deleter>;
+// TODO: Consider applying above hack, for sqlite_stmt
+/* using unique_sqlite3_stmt  = std::unique_ptr<sqlite3,  sqlite_deleter>; */ 
+
+unique_sqlite3 open_db(const char db_name[]);
+void throwSqliteException(unique_sqlite3& db, const std::string& errMsgPrefix, char* errMsgSuffix);
+void throwSqliteException(unique_sqlite3& db, const std::string& errMsgPrefix);

--- a/db_builder/Include/sqlite_helper.hpp
+++ b/db_builder/Include/sqlite_helper.hpp
@@ -11,5 +11,3 @@ using unique_sqlite3  = std::unique_ptr<sqlite3,  sqlite_deleter>;
 /* using unique_sqlite3_stmt  = std::unique_ptr<sqlite3,  sqlite_deleter>; */ 
 
 unique_sqlite3 open_db(const char db_name[]);
-void throwSqliteException(unique_sqlite3& db, const std::string& errMsgPrefix, char* errMsgSuffix);
-void throwSqliteException(unique_sqlite3& db, const std::string& errMsgPrefix);

--- a/db_builder/Include/sqlite_helper.hpp
+++ b/db_builder/Include/sqlite_helper.hpp
@@ -1,0 +1,7 @@
+#pragma once
+#include <sqlite3.h>
+#include <string>
+
+sqlite3* open_db(const char db_name[]);
+void throwSqliteException(sqlite3* db, const std::string& errMsgPrefix, char* errMsgSuffix);
+void throwSqliteException(sqlite3* db, const std::string& errMsgPrefix);

--- a/db_builder/Source/jsonInserter.cpp
+++ b/db_builder/Source/jsonInserter.cpp
@@ -1,0 +1,126 @@
+#include "jsonInserter.hpp"
+#include "sqlite_helper.hpp"
+#include <iostream>
+
+namespace
+{
+const std::vector<std::string> getColumnNames(sqlite3* db, const char tableName[]);
+sqlite3_stmt* prepareInsertStatement(sqlite3* db, const char table_name[], int colCount); // SQLi-insecure itself.
+// Caller should check if getColumnNames() (SQLi-safe method) returns any columns
+void bindJsonDictToInsertStatement(sqlite3_stmt* stmt, const std::vector<std::string>& colNames,
+                                   const Json::Value& json);
+} // namespace
+
+void fillTableWithArrOfDicts(sqlite3* db, const char table_name[], Json::Value json)
+{
+    const auto colNames = getColumnNames(db, table_name);
+    sqlite3_stmt* stmt = prepareInsertStatement(db, table_name, colNames.size());
+    if(colNames.size() == 0)
+    {
+        throwSqliteException(db, "Unable to fill not existing table");
+    }
+    for (auto dict = json.begin(); dict != json.end(); ++dict)
+    {
+        bindJsonDictToInsertStatement(stmt, colNames, *dict);
+        int rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE)
+        {
+            sqlite3_finalize(stmt);
+            throwSqliteException(db, "SQL Error: ");
+        }
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+    }
+    sqlite3_finalize(stmt);
+}
+
+namespace
+{
+const std::vector<std::string> getColumnNames(sqlite3* db, const char tableName[])
+{
+    sqlite3_stmt* stmt;
+    std::vector<std::string> output;
+    int rc = sqlite3_prepare_v2(db, "SELECT name FROM pragma_table_info(@table)", -1, &stmt, NULL);
+    if (rc != SQLITE_OK)
+    {
+        sqlite3_finalize(stmt);
+        throwSqliteException(db, "SQL Error: ");
+    }
+    sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, "@table"), tableName, -1, NULL);
+
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW)
+    {
+        std::string colName = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+        output.push_back(colName);
+    }
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE)
+    {
+        throwSqliteException(db, "SQL Error: ");
+    }
+    return output;
+}
+
+sqlite3_stmt* prepareInsertStatement(sqlite3* db, const char table_name[], int colCount)
+{
+    // Unfortunately sqlite_bind_param() doesn't work for table identifiers.
+    // We must resort to binding table_name using dumb string concat.
+    // This is generaly bad idea mainly because of SQL injection vurnelibity.
+    // However caller could ensure safety by passing valid colCount (at example from getColumnNames().size(), which is SQLi-safe method
+    // colCount == 0 means that table doesn't exist so we don't inject it name
+    // AFAIK this should be sufficient countermeasure. Prove me wrong.
+    // Also. In case of this parser, SQL injection isn't that big deal
+    // We are storing data from only one entity. He doesn't need SQLi to read or malform it :P
+    std::string query = std::string("INSERT INTO ") + table_name + " VALUES(";
+    for (int i = 0; i < colCount; ++i)
+    {
+        if (i != 0)
+        {
+            query += ',';
+        }
+        query += '?';
+    }
+    query += ')';
+
+    sqlite3_stmt* stmt;
+    int rc = sqlite3_prepare_v2(db, query.c_str(), -1, &stmt, NULL);
+    if (rc != SQLITE_OK)
+    {
+        sqlite3_finalize(stmt);
+        throwSqliteException(db, "SQL Error: ");
+    }
+    return stmt;
+}
+
+void bindJsonDictToInsertStatement(sqlite3_stmt* stmt, const std::vector<std::string>& colNames,
+                                   const Json::Value& dict)
+{
+    for (size_t i = 0; i < colNames.size(); ++i)
+    {
+        std::string colName = colNames[i];
+        const auto val = dict.find(&colName.front(), &colName.back() + 1);
+        const int paramIdx = i + 1; // sqlite3_bind() starts indexing from 1
+        if (val == NULL or val->isNull())
+        {
+            sqlite3_bind_null(stmt, paramIdx);
+        }
+        else if (val->isString())
+        {
+            sqlite3_bind_text(stmt, paramIdx, val->asCString(), -1, NULL);
+        }
+        else if (val->isInt() or val->isBool())
+        {
+            sqlite3_bind_int(stmt, paramIdx, val->asInt());
+        }
+        else if (val->isDouble())
+        {
+            sqlite3_bind_double(stmt, paramIdx, val->asDouble());
+        }
+        else
+        {
+            // fuck. Mixing exceptions with hand memory managment is nightmare.
+            // TODO: proper error handling here
+        }
+    }
+}
+} // namespace

--- a/db_builder/Source/jsonInserter.cpp
+++ b/db_builder/Source/jsonInserter.cpp
@@ -17,7 +17,7 @@ void fillTableWithArrOfDicts(unique_sqlite3& db, const char table_name[], Json::
     sqlite3_stmt* stmt = prepareInsertStatement(db, table_name, colNames.size());
     if(colNames.size() == 0)
     {
-        throwSqliteException(db, "Unable to fill not existing table");
+        throw std::runtime_error("Unable to fill not existing table");
     }
     for (auto dict = json.begin(); dict != json.end(); ++dict)
     {
@@ -26,7 +26,7 @@ void fillTableWithArrOfDicts(unique_sqlite3& db, const char table_name[], Json::
         if (rc != SQLITE_DONE)
         {
             sqlite3_finalize(stmt);
-            throwSqliteException(db, "SQL Error: ");
+            throw std::runtime_error(std::string("SQL Error: ") + sqlite3_errmsg(db.get()));
         }
         sqlite3_reset(stmt);
         sqlite3_clear_bindings(stmt);
@@ -44,7 +44,7 @@ const std::vector<std::string> getColumnNames(unique_sqlite3& db, const char tab
     if (rc != SQLITE_OK)
     {
         sqlite3_finalize(stmt);
-        throwSqliteException(db, "SQL Error: ");
+        throw std::runtime_error(std::string("SQL Error: ") + sqlite3_errmsg(db.get()));
     }
     sqlite3_bind_text(stmt, sqlite3_bind_parameter_index(stmt, "@table"), tableName, -1, NULL);
 
@@ -56,7 +56,7 @@ const std::vector<std::string> getColumnNames(unique_sqlite3& db, const char tab
     sqlite3_finalize(stmt);
     if (rc != SQLITE_DONE)
     {
-        throwSqliteException(db, "SQL Error: ");
+        throw std::runtime_error(std::string("SQL Error: ") + sqlite3_errmsg(db.get()));
     }
     return output;
 }
@@ -87,7 +87,7 @@ sqlite3_stmt* prepareInsertStatement(unique_sqlite3& db, const char table_name[]
     if (rc != SQLITE_OK)
     {
         sqlite3_finalize(stmt);
-        throwSqliteException(db, "SQL Error: ");
+        throw std::runtime_error(std::string("SQL Error: ") + sqlite3_errmsg(db.get()));
     }
     return stmt;
 }
@@ -118,8 +118,8 @@ void bindJsonDictToInsertStatement(sqlite3_stmt* stmt, const std::vector<std::st
         }
         else
         {
-            // fuck. Mixing exceptions with hand memory managment is nightmare.
-            // TODO: proper error handling here
+            sqlite3_finalize(stmt);
+            throw std::runtime_error("Unable to bind value to insert statement"); // poor msg. TODO: improve this
         }
     }
 }

--- a/db_builder/Source/main.cpp
+++ b/db_builder/Source/main.cpp
@@ -1,0 +1,42 @@
+#include "sqlite_helper.hpp"
+#include <sqlite3.h>
+
+void createTables(sqlite3* db);
+
+int main()
+{
+    sqlite3* db = open_db("database.sql");
+    createTables(db);
+}
+
+void createTables(sqlite3* db)
+{
+    // I have doubts about formating
+    constexpr char query[] = R"""(
+    CREATE TABLE IF NOT EXISTS "vocabTerms" ("nameRef"	TEXT,PRIMARY KEY("nameRef"));
+    CREATE TABLE IF NOT EXISTS "keywords" ("nameRef"	TEXT,PRIMARY KEY("nameRef"));
+    CREATE TABLE IF NOT EXISTS "spellSpeeds" ("nameRef"	TEXT,PRIMARY KEY("nameRef"));
+    CREATE TABLE IF NOT EXISTS "sets" ("nameRef"	TEXT,PRIMARY KEY("nameRef"));
+    CREATE TABLE IF NOT EXISTS "regions" ("nameRef"	TEXT,"abbreviation"	TEXT,PRIMARY KEY("nameRef"));
+    CREATE TABLE IF NOT EXISTS "rarities" ("nameRef"	TEXT,"value"	INTEGER,PRIMARY KEY("nameRef"));
+    CREATE TABLE IF NOT EXISTS "associatedCards" ("cardCode"	TEXT,"associatedCardCode"	TEXT,FOREIGN KEY("associatedCardCode") REFERENCES "cards"("cardCode"),FOREIGN KEY("cardCode") REFERENCES "cards"("cardCode"));
+    CREATE TABLE IF NOT EXISTS "languages" ("langCode"	TEXT,PRIMARY KEY("langCode"));
+    CREATE TABLE IF NOT EXISTS "keywordsTranslations" ("nameRef"	TEXT,"langCode"	TEXT,"description"	TEXT,"name"	TEXT,FOREIGN KEY("nameRef") REFERENCES "keywords"("nameRef"),PRIMARY KEY("nameRef","langCode"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"));
+    CREATE TABLE IF NOT EXISTS "vocabTermsTranslations" ("nameRef"	TEXT,"langCode"	TEXT,"name"	TEXT,"description"	TEXT,PRIMARY KEY("nameRef","langCode"),FOREIGN KEY("nameRef") REFERENCES "vocabTerms"("nameRef"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"));
+    CREATE TABLE IF NOT EXISTS "regionsTranslations" ("nameRef"	TEXT,"langCode"	TEXT,"iconAbsolutePath"	TEXT,"name"	TEXT,FOREIGN KEY("nameRef") REFERENCES "regions"("nameRef"),PRIMARY KEY("nameRef","langCode"));
+    CREATE TABLE IF NOT EXISTS "cards" ("cardCode"	TEXT UNIQUE,"regionRef"	TEXT,"attack"	INTEGER,"cost"	INTEGER,"health"	INTEGER,"artistName"	TEXT,"spellSpeedRef"	TEXT,"rarityRef"	TEXT,"collectible"	INTEGER,"set"	TEXT,FOREIGN KEY("set") REFERENCES "sets"("nameRef"),FOREIGN KEY("rarityRef") REFERENCES "rarities"("nameRef"),FOREIGN KEY("spellSpeedRef") REFERENCES "spellSpeeds"("nameRef"),PRIMARY KEY("cardCode"),FOREIGN KEY("regionRef") REFERENCES "regions"("nameRef"));
+    CREATE TABLE IF NOT EXISTS "cardKeywords" ("cardCode"	TEXT,"keywordRef"	INTEGER,FOREIGN KEY("keywordRef") REFERENCES "keywords"("nameRef"),FOREIGN KEY("cardCode") REFERENCES "cards"("cardCode"));
+    CREATE TABLE IF NOT EXISTS "cardAssetsTranslations" ("cardCode"	TEXT,"gameAbsolutePath"	TEXT,"fullAbsolutePath"	TEXT,FOREIGN KEY("cardCode") REFERENCES "cards"("cardCode"));
+    CREATE TABLE IF NOT EXISTS "setsTranslations" ("langCode"	TEXT,"nameRef"	TEXT,"iconAbsolutePath"	TEXT,"name"	TEXT,PRIMARY KEY("langCode","nameRef"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"),FOREIGN KEY("nameRef") REFERENCES "sets"("nameRef"));
+    CREATE TABLE IF NOT EXISTS "raritiesTranslations" ("langCode"	TEXT,"nameRef"	TEXT,"name"	TEXT,PRIMARY KEY("langCode","nameRef"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"),FOREIGN KEY("nameRef") REFERENCES "rarities"("nameRef"));
+    CREATE TABLE IF NOT EXISTS "cardTranslations" ("cardCode"	TEXT,"langCode"	TEXT,"descriptionRaw"	TEXT,"levelupDescriptionRaw"	TEXT,"flavorText"	TEXT,"name"	TEXT,"supertype"	TEXT,"type"	TEXT,PRIMARY KEY("cardCode","langCode"),FOREIGN KEY("cardCode") REFERENCES "cards"("cardCode"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"));
+    CREATE TABLE IF NOT EXISTS "cardSubtypesTranslation" ("cardCode"	TEXT,"langCode"	TEXT,"subtype"	TEXT,FOREIGN KEY("cardCode") REFERENCES "cards"("cardCode"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"));
+    CREATE TABLE IF NOT EXISTS "spellSpeedsTranslations" ("nameRef"	TEXT,"langCode"	TEXT,"name"	TEXT,FOREIGN KEY("langCode") REFERENCES "languages"("langCode"),PRIMARY KEY("nameRef","langCode"),FOREIGN KEY("nameRef") REFERENCES "spellSpeeds"("nameRef"));
+    )""";
+    char* errMsg = NULL;
+    int result_code = sqlite3_exec(db, query, NULL, NULL, &errMsg);
+    if (result_code != SQLITE_OK)
+    {
+        throwSqliteException(db, "SQL Error: ", errMsg);
+    }
+}

--- a/db_builder/Source/main.cpp
+++ b/db_builder/Source/main.cpp
@@ -52,15 +52,12 @@ void createTables(unique_sqlite3& db)
     CREATE TABLE IF NOT EXISTS "cardSubtypesTranslation" ("cardCode"	TEXT,"langCode"	TEXT,"subtype"	TEXT,FOREIGN KEY("cardCode") REFERENCES "cards"("cardCode"),FOREIGN KEY("langCode") REFERENCES "languages"("langCode"));
     CREATE TABLE IF NOT EXISTS "spellSpeedsTranslations" ("nameRef"	TEXT,"langCode"	TEXT,"name"	TEXT,FOREIGN KEY("langCode") REFERENCES "languages"("langCode"),PRIMARY KEY("nameRef","langCode"),FOREIGN KEY("nameRef") REFERENCES "spellSpeeds"("nameRef"));
     )""";
-    char* errMsg = NULL;
-    int result_code = sqlite3_exec(db.get(), query, NULL, NULL, &errMsg);
+    int result_code = sqlite3_exec(db.get(), query, NULL, NULL, NULL);
     if (result_code != SQLITE_OK)
     {
-        throwSqliteException(db, "SQL Error: ", errMsg);
+        throw std::runtime_error(std::string("SQL Error: ") + sqlite3_errmsg(db.get()));
     }
 }
-
-
 
 std::string getJsonMemberNameWithoutNuls(Json::ValueIteratorBase it)
 {

--- a/db_builder/Source/main.cpp
+++ b/db_builder/Source/main.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 #include <json/json.h>
 #include <sqlite3.h>
+#include <cstring>
+
 
 void fillDbWithRiotJson(unique_sqlite3& db, Json::Value json);
 void createTables(unique_sqlite3& db);

--- a/db_builder/Source/sqlite_helper.cpp
+++ b/db_builder/Source/sqlite_helper.cpp
@@ -1,0 +1,28 @@
+#include "sqlite_helper.hpp"
+#include <stdexcept>
+
+sqlite3* open_db(const char db_name[])
+{
+    sqlite3* db; // Maybe I should wrap this into simple RAII handle or smart pointer?
+    int resultCode = sqlite3_open(db_name, &db);
+    if (resultCode != SQLITE_OK)
+    {
+        throwSqliteException(db, "Can't open database: ");
+    }
+    return db;
+}
+
+void throwSqliteException(sqlite3* db, const std::string& errMsgPrefix, char* errMsgSuffix)
+{
+    std::string errMsg = errMsgPrefix + errMsgSuffix;
+    sqlite3_free(errMsgSuffix);
+    sqlite3_close(db); // I have doubts with this one. Mixing exceptions with hand memory managment is nightmare.
+    throw std::runtime_error(errMsg);
+}
+
+void throwSqliteException(sqlite3* db, const std::string& errMsgPrefix)
+{
+    std::string errMsg = errMsgPrefix + sqlite3_errmsg(db);
+    sqlite3_close(db); // I have doubts with this one. Mixing exceptions with hand memory managment is nightmare.
+    throw std::runtime_error(errMsg);
+}

--- a/db_builder/Source/sqlite_helper.cpp
+++ b/db_builder/Source/sqlite_helper.cpp
@@ -13,16 +13,3 @@ unique_sqlite3 open_db(const char db_name[])
     }
     return unique_sqlite3(tmp);
 }
-
-void throwSqliteException(unique_sqlite3& db, const std::string& errMsgPrefix, char* errMsgSuffix)
-{
-    std::string errMsg = errMsgPrefix + errMsgSuffix;
-    sqlite3_free(errMsgSuffix);
-    throw std::runtime_error(errMsg);
-}
-
-void throwSqliteException(unique_sqlite3& db, const std::string& errMsgPrefix)
-{
-    std::string errMsg = errMsgPrefix + sqlite3_errmsg(db.get());
-    throw std::runtime_error(errMsg);
-}


### PR DESCRIPTION
Add proof of concept of database builder.

Contrary to [previous attempt](https://github.com/marcinwozniak0/BakcylProgramowania_2020/tree/parser) this one is automated.
It iterates over json objects and inserts fields into the same named columns (that required us to [adjust database model](https://github.com/marcinwozniak0/BakcylProgramowania_2020/issues/23#issuecomment-789335539))

Executable is outputted to <build_dir>/bin/db_builder. You have to have json [`globals-ru_ru.json`](https://dd.b.pvp.net/latest/core/ru_ru/data/globals-ru_ru.json) in path (it will also work if you save json in other language as `globals-ru_ru.json`. ya, ya. This sucks, but it is sufficient for this PoC). 

I haven't add support for jsons like `setX` yet, but it shouldn't be hard to do this.

Filling of localization-dependent tables is not completed - `langCode` column is nulled. We have to add support for injecting it.
![2021-03-03-00_51_30](https://user-images.githubusercontent.com/46008403/109731301-e6b5c780-7bb2-11eb-8d12-1cb35b0e6e11.png).

It is missing tests, and has poor error handling. TODO.

This pull request has applied bugfix from #35. It would be nice to merge that first


