### PR TITLE
Fix card type

### DIFF
--- a/db/card_api/Include/utilities.hpp
+++ b/db/card_api/Include/utilities.hpp
@@ -23,7 +23,7 @@ const std::string GET_ALL_CARDS_QUERY = R"""(
      levelupDescriptionRaw,
      flavorText,
      supertype,
-     'type',
+     "type",
      sets.name,
      sets.nameRef,
      regions.name,


### PR DESCRIPTION
I mistook SQL escaping mechanisms
'foo' is an SQL string
"foo" is an SQL identifier (column/table/etc)

So instead of proper card type like "Spell" or "Unit", we have been returning "type" literal